### PR TITLE
Close InputStream after use

### DIFF
--- a/src/main/java/com/resend/util/FileUtils.java
+++ b/src/main/java/com/resend/util/FileUtils.java
@@ -12,10 +12,11 @@ public class FileUtils {
 
     private static byte[] loadResourceFile(String filename) throws IOException {
         ClassLoader classLoader = FileUtils.class.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream(filename);
-        if (inputStream == null) {
-            throw new IOException("Resource not found: " + filename);
+        try (InputStream inputStream = classLoader.getResourceAsStream(filename)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + filename);
+            }
+            return inputStream.readAllBytes();
         }
-        return inputStream.readAllBytes();
     }
 }


### PR DESCRIPTION
We need to close the `InputStream` ourselves, since the [docs](https://docs.oracle.com/en/java/javase/21/docs//api/java.base/java/io/InputStream.html#readAllBytes()) for `readAllBytes` says:
> This method does not close the input stream.